### PR TITLE
feat: add support for dynamic request action and switching context to…

### DIFF
--- a/src/message-dispatcher.decorator.ts
+++ b/src/message-dispatcher.decorator.ts
@@ -10,7 +10,7 @@ export enum Action {
 export const DispatcherParamsMetadata = 'dispatcher-options';
 
 export interface DispatcherOptions {
-  action: Action;
+  action: ((req: any, data: any) => Action) | string;
   objectIdGetter: (req: any, data: any) => string | string[];
 }
 

--- a/src/message.dto.ts
+++ b/src/message.dto.ts
@@ -50,6 +50,7 @@ export enum MsgObjectType {
   PortfolioGroup = 'urn:forlagshuset:object:portfolio:group',
   PortfolioUser = 'urn:forlagshuset:object:portfolio:user',
   ErudioRoleAssignment = 'urn:forlagshuset:object:erudio:role-assignment',
+  ErudioObjectFusion = 'urn:forlagshuset:object:erudio:object-fusion'
 }
 
 export interface ObjectMsg {

--- a/test/message-dispatcher.spec.ts
+++ b/test/message-dispatcher.spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { AsyncLoggerProvider } from '../src/async-logger-provider.interface';
+import { Action } from '../src/message-dispatcher.decorator';
 import { MessageDispatcherInterceptor } from '../src/message-dispatcher.interceptor';
 import {
   Message,
@@ -68,6 +69,31 @@ describe('Message Dispatcher', () => {
         expect(transport.log).toHaveBeenCalledTimes(1);
         expect(transport.log).toHaveBeenCalledWith(subject, {
           action: { type: 'urn:forlagshuset:action:object', verb: 'created' },
+          object: {
+            id,
+            type: 'urn:forlagshuset:object:erudio:namespace',
+          },
+          payload: { id },
+          service: {
+            id: serviceId,
+            type: 'urn:forlagshuset:service:app',
+          },
+          timestamp: expect.anything(),
+        });
+      });
+
+      it('should create and send message with dynamic action', async () => {
+        const res = await request(app.getHttpServer())
+          .get(`/test/dynamic-action/${id}`)
+          .expect(200);
+
+        expect(res.text).toEqual(JSON.stringify({ id: id }));
+        expect(transport.log).toHaveBeenCalledTimes(1);
+        expect(transport.log).toHaveBeenCalledWith(subject, {
+          action: {
+            type: 'urn:forlagshuset:action:object',
+            verb: Action.UPDATED,
+          },
           object: {
             id,
             type: 'urn:forlagshuset:object:erudio:namespace',

--- a/test/mocks/message-dispatcher-test.controller.ts
+++ b/test/mocks/message-dispatcher-test.controller.ts
@@ -48,6 +48,19 @@ export class MessageDispatcherTestController {
 
   @MessageEventEmitter({
     objectIdGetter: (request) => request.params.id,
+    action: (request) => request.action as Action,
+  })
+  @Get('dynamic-action/:id/')
+  async testWithDynamicAction(
+    @Param() params: { id: string },
+    @Req() req,
+  ): Promise<{ id: string }> {
+    req.action = Action.UPDATED;
+    return { id: params.id };
+  }
+
+  @MessageEventEmitter({
+    objectIdGetter: (request) => request.params.id,
     action: Action.CREATED,
   })
   @Get(':id')


### PR DESCRIPTION
Proposed changed:

- added new message object type for data incoming from fusion processor
- action for mutation can be set up dynamically via function
- when incoming context is rpc type, it is being translated to rpc to provide access to data 
- then data can be used to gather action type from incoming request without malformation of mutation payload